### PR TITLE
Disable variable expansion

### DIFF
--- a/pyinstrument/magic/magic.py
+++ b/pyinstrument/magic/magic.py
@@ -4,7 +4,7 @@ import urllib.parse
 from ast import parse
 
 from IPython import get_ipython  # type: ignore
-from IPython.core.magic import Magics, line_cell_magic, magics_class
+from IPython.core.magic import Magics, line_cell_magic, magics_class, no_var_expand
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 from IPython.display import IFrame, display
 
@@ -71,6 +71,7 @@ class PyinstrumentMagic(Magics):
         nargs="*",
         help="When used as a line magic, the code to profile",
     )
+    @no_var_expand
     @line_cell_magic
     def pyinstrument(self, line, cell=None):
         """

--- a/test/test_ipython_magic.py
+++ b/test/test_ipython_magic.py
@@ -68,6 +68,15 @@ def test_magic_empty_line(ip):
     ip.run_line_magic("pyinstrument", line="")
 
 
+@pytest.mark.ipythonmagic
+def test_magic_no_variable_expansion(ip, capsys):
+    ip.run_line_magic("pyinstrument", line="print(\"hello {len('world')}\")")
+
+    captured = capsys.readouterr()
+    assert "hello {len('world')}" in captured.out
+    assert "hello 5" not in captured.out
+
+
 # Utils #
 
 


### PR DESCRIPTION
Uses [`@no_var_expand`](https://ipython.readthedocs.io/en/stable/api/generated/IPython.core.magic.html#IPython.core.magic.no_var_expand) to disable IPython variable interpolation. This decorator is supported since in IPython 7.3 and is used in other projects and magics which offer execution of user code in special contexts (e.g. the IPython built-in magics such as `%debug`, `%%prun`, `%time`, or in rpy2's `%R` and `%%R` magics).